### PR TITLE
Switch to site-only use of MPD

### DIFF
--- a/mpd/config.py
+++ b/mpd/config.py
@@ -6,8 +6,8 @@ import ruamel
 
 import llnl.util.tty as tty
 
-import spack.environment as ev
 import spack.config
+import spack.environment as ev
 import spack.util.spack_yaml as syaml
 
 from . import util
@@ -27,7 +27,7 @@ def _process_exists(pid):
 
 
 def selected_projects_dir():
-    return user_config_dir() / "active"
+    return mpd_config_dir() / "selected"
 
 
 def selected_projects():
@@ -46,20 +46,20 @@ def selected_project_token():
     return selected_projects_dir() / session_id()
 
 
-def user_config_dir():
-    return Path(spack.config.get('config:mpd_user_dir')).resolve()
+def mpd_config_dir():
+    return Path(spack.config.get("config:mpd_dir")).resolve()
 
 
 def mpd_packages():
-    return user_config_dir() / "packages"
+    return mpd_config_dir() / "packages"
 
 
-def user_config_file():
-    return user_config_dir() / "config"
+def mpd_config_file():
+    return mpd_config_dir() / "config"
 
 
-def user_config():
-    config_file = user_config_file()
+def mpd_config():
+    config_file = mpd_config_file()
     if not config_file.exists():
         return None
 
@@ -140,7 +140,7 @@ def project_config_from_args(args):
 
 
 def mpd_project_exists(project_name):
-    config_file = user_config_file()
+    config_file = mpd_config_file()
     config = None
     if config_file.exists():
         with open(config_file, "r") as f:
@@ -157,7 +157,7 @@ def mpd_project_exists(project_name):
 
 
 def update(project_config, status=None, deployed_env=None):
-    config_file = user_config_file()
+    config_file = mpd_config_file()
     config = None
     if config_file.exists():
         with open(config_file, "r") as f:
@@ -181,7 +181,7 @@ def update(project_config, status=None, deployed_env=None):
 
 
 def refresh(project_name, new_variants):
-    config_file = user_config_file()
+    config_file = mpd_config_file()
     if config_file.exists():
         with open(config_file, "r") as f:
             config = syaml.load(f)
@@ -223,7 +223,7 @@ def refresh(project_name, new_variants):
 
 
 def rm_config(project_name):
-    config_file = user_config_file()
+    config_file = mpd_config_file()
     if config_file.exists():
         with open(config_file, "r") as f:
             config = syaml.load(f)
@@ -239,7 +239,7 @@ def rm_config(project_name):
 
 def project_config(name, config=None):
     if config is None:
-        config_file = user_config_file()
+        config_file = mpd_config_file()
         if config_file.exists():
             with open(config_file, "r") as f:
                 config = syaml.load(f)
@@ -261,7 +261,7 @@ def project_config(name, config=None):
 
 def update_cache():
     # Update environment status in user configuration
-    config = user_config()
+    config = mpd_config()
     if not config:
         return
 
@@ -280,7 +280,7 @@ def update_cache():
             adjusted = True
 
     if adjusted:
-        with open(user_config_file(), "w") as f:
+        with open(mpd_config_file(), "w") as f:
             syaml.dump(config, stream=f)
 
     # Remove stale selected project tokens

--- a/mpd/deploy.py
+++ b/mpd/deploy.py
@@ -8,7 +8,7 @@ import spack.environment as ev
 from spack.repo import PATH
 from spack.spec import Spec
 
-from .config import selected_project_config, update, user_config_dir
+from .config import mpd_config_dir, selected_project_config, update
 from .preconditions import State, preconditions
 from .util import bold, make_yaml_file
 
@@ -61,7 +61,7 @@ def deploy(config, deployed_name, parallel, force):
         concretizer=dict(unify=True, reuse=True),
         develop=developed_packages,
     )
-    env_file = make_yaml_file(deployed_name, dict(spack=full_block), prefix=user_config_dir())
+    env_file = make_yaml_file(deployed_name, dict(spack=full_block), prefix=mpd_config_dir())
 
     if ev.exists(deployed_name) and force:
         ev.read(deployed_name).destroy()

--- a/mpd/list_projects.py
+++ b/mpd/list_projects.py
@@ -68,7 +68,7 @@ def _no_known_projects():
 
 
 def list_projects():
-    cfg = config.user_config()
+    cfg = config.mpd_config()
     if not cfg:
         _no_known_projects()
         return
@@ -96,7 +96,8 @@ def list_projects():
         indicator, color_code, warning = format_fields(key, selected)
         msg += maybe_with_color(
             color_code,
-            f"\n {indicator} {key:<{name_width}}    {status:<{status_width}}    {deployed:<{deployed_width}} {warning}",
+            f"\n {indicator} {key:<{name_width}}    {status:<{status_width}}"
+            f"    {deployed:<{deployed_width}} {warning}",
         )
     msg += "\n"
     print()
@@ -104,7 +105,7 @@ def list_projects():
 
 
 def project_path(project_name, path_kind):
-    cfg = config.user_config()
+    cfg = config.mpd_config()
     if not cfg:
         _no_known_projects()
         return
@@ -121,7 +122,7 @@ def project_path(project_name, path_kind):
 
 
 def project_details(project_names):
-    cfg = config.user_config()
+    cfg = config.mpd_config()
     if not cfg:
         _no_known_projects()
         return

--- a/mpd/select.py
+++ b/mpd/select.py
@@ -3,9 +3,8 @@ import llnl.util.tty as tty
 import spack.environment as ev
 
 from . import config
-from .preconditions import preconditions, State
+from .preconditions import State, preconditions
 from .util import bold
-
 
 SUBCOMMAND = "select"
 
@@ -20,7 +19,7 @@ def setup_subparser(subparsers):
 def process(args):
     preconditions(State.INITIALIZED, ~State.ACTIVE_ENVIRONMENT)
 
-    cfg = config.user_config()
+    cfg = config.mpd_config()
     if not cfg:
         tty.error(f"No existing MPD projects--cannot select {args.project}.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,22 @@
-from pathlib import Path
 import pytest
 
-from spack.extensions.mpd import config
+import spack
+from spack.extensions.mpd import config, init
 from spack.main import SpackCommand
 
 
 @pytest.fixture(scope="module")
-def tmp_home_dir(tmp_path_factory):
-    path = tmp_path_factory.mktemp("init")
+def tmp_mpd_dir(tmp_path_factory):
+    real_path = config.mpd_config_dir()
+    path_for_test = tmp_path_factory.mktemp("init")
     with pytest.MonkeyPatch.context() as m:
-        m.setattr(Path, "home", lambda: path)
-        yield
+        m.setattr(init, "MPD_DIR", path_for_test)
+        yield str(path_for_test)
+    spack.config.set("config:mpd_dir", str(real_path))
 
 
 @pytest.fixture(scope="module")
-def with_mpd_init(tmp_home_dir):
+def with_mpd_init(tmp_mpd_dir):
     SpackCommand("mpd")("init")
     yield
-    SpackCommand("repo")("rm", str(config.user_config_dir()))
+    SpackCommand("repo")("rm", "--scope=site", str(config.mpd_config_dir()))

--- a/tests/test_mpd_init.py
+++ b/tests/test_mpd_init.py
@@ -4,31 +4,30 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import pytest
 
-from spack.main import SpackCommand
 import spack.paths
+from spack.main import SpackCommand
 
 mpd = SpackCommand("mpd")
 
 
 # Should replace this with a fixture
 @pytest.fixture
-def tmp_home_dir_with_cleanup(tmp_home_dir):
+def tmp_mpd_dir_with_cleanup(tmp_mpd_dir):
     try:
         yield
     finally:
-        SpackCommand("repo")("rm", "local-mpd", fail_on_error=False)
+        SpackCommand("repo")("rm", "--scope=site", tmp_mpd_dir)
 
 
-def test_mpd_init(tmp_home_dir_with_cleanup):
+def test_mpd_init(tmp_mpd_dir_with_cleanup):
     out = mpd("init")
     assert f"Using Spack instance at {spack.paths.prefix}" in out
-    assert "Added repo with namespace 'local-mpd'" in out
+    assert "Added repo with namespace 'mpd'" in out
 
     out = mpd("init")
-    assert f"Using Spack instance at {spack.paths.prefix}" in out
-    assert "Warning: MPD already initialized on this system" in out
+    assert f"Warning: MPD already initialized for Spack instance at {spack.paths.prefix}" in out
 
     out = mpd("init", "-f", "-y")
     assert "Warning: Reinitializing MPD on this system will remove all MPD projects" in out
     assert f"Using Spack instance at {spack.paths.prefix}" in out
-    assert "Added repo with namespace 'local-mpd'" in out
+    assert "Added repo with namespace 'mpd'" in out


### PR DESCRIPTION
**This is a breaking change**.  If existing MPD projects must work after this change is committed, a migration path will need to be developed.

> [!NOTE]  
> For the developers:
> - The `var/mpd` subdirectory will need to be added to the `spack/.gitignore` file of the FNAL fork.
> - The equivalent of `spack mpd init` should be invoked as part of the bootstrap script.