### PR TITLE
Make status work even if mpd has not been initialized yet

### DIFF
--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -60,7 +60,7 @@ Now that MPD has been installed, you can [initialize your system to use MPD](Ini
 
 ### Running MPD's unit tests
 
-MPD has several unit tests that should run successfully for any system on which it is installed and initialized.  If you wish to run the unit tests, invoke:
+MPD has several unit tests that should run successfully for any system on which it is installed.  If you wish to run the unit tests, invoke:
 
 ```console
 $ spack unit-test --extension=mpd

--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -60,7 +60,7 @@ Now that MPD has been installed, you can [initialize your system to use MPD](Ini
 
 ### Running MPD's unit tests
 
-MPD has several unit tests that should run successfully for any system on which it is installed.  If you wish to run the unit tests, invoke:
+MPD has several unit tests that should run successfully for any system on which it is installed and initialized.  If you wish to run the unit tests, invoke:
 
 ```console
 $ spack unit-test --extension=mpd

--- a/mpd/cmd/mpd.py
+++ b/mpd/cmd/mpd.py
@@ -40,12 +40,13 @@ def setup_parser(subparser):
 
 
 def mpd(parser, args):
+    is_initialized = subcommand_modules["init"].initialized()
     for m in subcommand_modules.values():
         scmds = [m.SUBCOMMAND] + getattr(m, "ALIASES", [])
         if args.mpd_subcommand not in scmds:
             continue
 
-        if args.mpd_subcommand != "init":
+        if args.mpd_subcommand != "init" and is_initialized:
             # Each non-init command either relies on the cached information in
             # the user configuration or the cached selected project (if it exists).
             config.update_cache()

--- a/mpd/config.py
+++ b/mpd/config.py
@@ -26,8 +26,9 @@ def _process_exists(pid):
     return True
 
 
-def selected_projects_dir():
-    return mpd_config_dir() / "selected"
+def selected_projects_dir(missing_ok=True):
+    config_dir = mpd_config_dir(missing_ok)
+    return config_dir / "selected" if config_dir else None
 
 
 def selected_projects():
@@ -42,22 +43,29 @@ def session_id():
     return f"{os.getsid(os.getpid())}"
 
 
-def selected_project_token():
-    return selected_projects_dir() / session_id()
+def selected_project_token(missing_ok=True):
+    projects_dir = selected_projects_dir(missing_ok)
+    if not projects_dir and missing_ok:
+        return None
+    return projects_dir / session_id()
 
 
-def mpd_config_dir():
+def mpd_config_dir(missing_ok=False):
     config_dir = spack.config.get("config:mpd_dir")
-    return Path(config_dir).resolve() if config_dir else None
+    if not config_dir and missing_ok:
+        return None
+    return Path(config_dir).resolve()
 
 
-def mpd_config_file():
-    config_dir = mpd_config_dir()
-    return config_dir / "config" if config_dir else None
+def mpd_config_file(missing_ok=False):
+    config_dir = mpd_config_dir(missing_ok)
+    if not config_dir and missing_ok:
+        return None
+    return config_dir / "config"
 
 
 def mpd_config():
-    config_file = mpd_config_file()
+    config_file = mpd_config_file(missing_ok=True)
     if not config_file or not config_file.exists():
         return None
 
@@ -297,8 +305,8 @@ def update_cache():
 
 
 def selected_project(missing_ok=True):
-    token = selected_project_token()
-    if token.exists():
+    token = selected_project_token(missing_ok)
+    if token and token.exists():
         return token.read_text()
 
     if missing_ok:

--- a/mpd/config.py
+++ b/mpd/config.py
@@ -47,16 +47,18 @@ def selected_project_token():
 
 
 def mpd_config_dir():
-    return Path(spack.config.get("config:mpd_dir")).resolve()
+    config_dir = spack.config.get("config:mpd_dir")
+    return Path(config_dir).resolve() if config_dir else None
 
 
 def mpd_config_file():
-    return mpd_config_dir() / "config"
+    config_dir = mpd_config_dir()
+    return config_dir / "config" if config_dir else None
 
 
 def mpd_config():
     config_file = mpd_config_file()
-    if not config_file.exists():
+    if not config_file or not config_file.exists():
         return None
 
     with open(config_file, "r") as f:

--- a/mpd/init.py
+++ b/mpd/init.py
@@ -30,7 +30,7 @@ def setup_subparser(subparsers):
 
 
 def initialized():
-    config_dir = config.mpd_config_dir()
+    config_dir = config.mpd_config_dir(missing_ok=True)
     return config_dir and config_dir.exists()
 
 
@@ -38,8 +38,6 @@ def process(args):
     spack_root = spack.paths.prefix
 
     local_dir = MPD_DIR.resolve()
-    spack.config.set("config:mpd_dir", str(local_dir))
-
     if initialized() and not args.force:
         assert local_dir.exists()
         tty.warn(f"MPD already initialized for Spack instance at {spack_root}")
@@ -55,6 +53,8 @@ def process(args):
             + indent
             + "Please contact scisoft-team@fnal.gov for guidance."
         )
+
+    spack.config.set("config:mpd_dir", str(local_dir), scope="site")
 
     if local_dir.exists() and args.force:
         tty.warn("Reinitializing MPD on this system will remove all MPD projects")

--- a/mpd/init.py
+++ b/mpd/init.py
@@ -30,7 +30,8 @@ def setup_subparser(subparsers):
 
 
 def initialized():
-    return config.mpd_config_dir().exists()
+    config_dir = config.mpd_config_dir()
+    return config_dir and config_dir.exists()
 
 
 def process(args):

--- a/mpd/list_projects.py
+++ b/mpd/list_projects.py
@@ -3,6 +3,7 @@ import llnl.util.tty as tty
 import spack.util.spack_yaml as syaml
 
 from . import config
+from .preconditions import State, preconditions
 from .util import bold, cyan, maybe_with_color
 
 SUBCOMMAND = "list"
@@ -138,6 +139,8 @@ def project_details(project_names):
 
 
 def process(args):
+    preconditions(State.INITIALIZED)
+
     if args.project:
         project_details(args.project)
     elif args.top:

--- a/mpd/preconditions.py
+++ b/mpd/preconditions.py
@@ -33,7 +33,9 @@ def check_initialized(conditions):
         return None
     if init.initialized() == should_be_initialized:
         return None
-    return f"MPD must{sign(should_be_initialized)} be initialized"
+    if should_be_initialized is True:
+        return f"MPD not initialized--invoke {bold('spack mpd init')}"
+    return "MPD must not be initialized"
 
 
 def check_selected(conditions):

--- a/mpd/status.py
+++ b/mpd/status.py
@@ -2,8 +2,9 @@ import llnl.util.tty as tty
 
 import spack.environment as ev
 
-from . import config, init
-from .util import bold, cyan
+from . import config
+from .preconditions import State, preconditions
+from .util import cyan
 
 SUBCOMMAND = "status"
 
@@ -19,9 +20,7 @@ def _environment_status(status_str):
 
 
 def process(args):
-    if not init.initialized():
-        tty.warn("MPD not initialized--invoke: " + bold("spack mpd init"))
-        return
+    preconditions(State.INITIALIZED)
 
     selected = config.selected_project()
     if not selected:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,19 @@ from spack.main import SpackCommand
 
 @pytest.fixture
 def tmp_mpd_dir(tmp_path_factory):
-    real_path = config.mpd_config_dir()
+    project = config.selected_project()
+    real_path = config.mpd_config_dir(missing_ok=True)
     path_for_test = tmp_path_factory.mktemp("mpd")
+    mpd_dir = (path_for_test / "init").resolve()
     with pytest.MonkeyPatch.context() as m:
-        mpd_dir = (path_for_test / "init").resolve()
         m.setattr(init, "MPD_DIR", mpd_dir)
         yield mpd_dir
-    spack.config.set("config:mpd_dir", str(real_path))
+    if not real_path:
+        SpackCommand("config")("--scope", "site", "rm", "config:mpd_dir")
+    else:
+        spack.config.set("config:mpd_dir", str(real_path), scope="site")
+    if project:
+        config.select(project)
 
 
 @pytest.fixture

--- a/tests/test_mpd_new_project.py
+++ b/tests/test_mpd_new_project.py
@@ -30,10 +30,13 @@ def new_project(name, top=None, srcs=None, cwd=None):
         cm = fs.working_dir(cwd, create=True)
 
     with cm:
+        old_project = config.selected_project()
         try:
             yield mpd("new-project", *arguments)
         finally:
             mpd("rm-project", "--force", name)
+            if old_project:
+                mpd("select", old_project)
 
 
 def test_new_project_all_default_paths(with_mpd_init, tmp_path):
@@ -83,7 +86,7 @@ def test_new_project_no_default_paths(with_mpd_init, tmp_path):
         assert f"sources area: {srcs_d}" in out
 
 
-def test_mpd_refresh(tmp_path):
+def test_mpd_refresh(with_mpd_init, tmp_path):
     with new_project(name="e", cwd=tmp_path):
         cfg = config.selected_project_config()
         out = mpd("refresh")


### PR DESCRIPTION
Currently simply installing `spack-mpd` but not initializing it, will result in
```console
$ spack mpd status
==> Error: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
```

The changes in here fix that by making `mpd_config_dir` and `mpd_config_file` return `None` in case `config:mpd_dir` has not yet been added to the spack configuration. This makes the experience a bit more pleasant:

```console
$ spack mpd status
==> Warning: MPD not initialized--invoke: spack mpd init
```

The changes I made here are quite limited, and only enough to propagate the necessary information far enough without running into a `TypeError` from the `Path` constructor to do the checks in `init.initialized`. I think this should be enough to also fix potential issues in other sub commands that check the initialization status.

I didn't see an easy way to add unit tests for this as they assume that `init` has been called. If there is or if you want unit tests, let me know, and I can try to add them.