### PR TITLE
Suppress dev CMake noise

### DIFF
--- a/mpd/build.py
+++ b/mpd/build.py
@@ -51,6 +51,7 @@ def configure_cmake_project(project_config):
         "cmake",
         "--preset",
         "default",
+        "-Wno-dev",
         project_config["source"],
         "-B",
         project_config["build"],


### PR DESCRIPTION
Should this be an option passed to build? Most of these "dev" warnings will go away when we move to the next version of art...