### PR TITLE
Put try except around CMakePackage import

### DIFF
--- a/mpd/config.py
+++ b/mpd/config.py
@@ -32,8 +32,11 @@ except ImportError:
 
 from spack.repo import PATH, UnknownPackageError
 from spack.spec import Spec
-PATH.repos
-from spack_repo.builtin.build_systems.cmake import CMakePackage
+try:
+    from spack.build_systems.cmake import CMakePackage
+except:
+    PATH.repos
+    from spack_repo.builtin.build_systems.cmake import CMakePackage
 
 from . import init
 from .util import cyan, gray, green, magenta, spack_cmd_line, yellow


### PR DESCRIPTION
This allows spack-mpd to work with pre 1.0 spack