### PR TITLE
Cetmodules 4 support

### DIFF
--- a/mpd/concretize.py
+++ b/mpd/concretize.py
@@ -17,6 +17,7 @@ except ImportError:
 import spack.builder as builder
 import spack.cmd
 import spack.compilers
+import spack.compilers.config
 import spack.config
 import spack.environment as ev
 import spack.llnl.util.tty as tty

--- a/mpd/concretize.py
+++ b/mpd/concretize.py
@@ -121,7 +121,7 @@ def cmake_lists_preamble(project_name, develop_cetmodules=False):
     date = time.strftime("%Y-%m-%d")
     preamble = """cmake_minimum_required(VERSION 3.31 FATAL_ERROR)
 enable_testing()
-include(develop)
+include(develop.cmake)
 
 """
     if develop_cetmodules:

--- a/mpd/concretize.py
+++ b/mpd/concretize.py
@@ -119,7 +119,7 @@ endmacro()
 
 def cmake_lists_preamble(project_name, develop_cetmodules=False):
     date = time.strftime("%Y-%m-%d")
-    preamble = """cmake_minimum_required(VERSION 3.31 FATAL_ERROR)
+    preamble = """cmake_minimum_required(VERSION 3.24...4.1 FATAL_ERROR)
 enable_testing()
 include(develop.cmake)
 

--- a/mpd/concretize.py
+++ b/mpd/concretize.py
@@ -131,9 +131,8 @@ include(develop)
 FetchContent_Declare(
   cetmodules
   GIT_REPOSITORY https://github.com/FNALssi/cetmodules
-  GIT_TAG v4-branch
-  # GIT_TAG fd6ebf45
-  FIND_PACKAGE_ARGS 3.99.00
+  GIT_TAG 39f03b11 # v4.01.01
+  FIND_PACKAGE_ARGS 4.01.01
   )
 
 FetchContent_MakeAvailable(cetmodules)


### PR DESCRIPTION
- **Style fixes only**
- **Cope with `CMakePresets.json` with schema version >3**
- **MPD uses/supports Cetmodules 4-ish**
- **Improve preset handling**
- **Require Cetmodules 4.01.01**
- **Must specify file for local include with CMake >=4**
- **Reconcile CMake minimum version with actual requirements**
