### PR TITLE
Allow for repository names that differ from Spack package names

### DIFF
--- a/mpd/concretize.py
+++ b/mpd/concretize.py
@@ -107,6 +107,7 @@ macro(develop pkg)
                                 WORKING_DIRECTORY ${{CWD}})")
   set(CMAKE_INSTALL_PREFIX ${{${{pkg}}_INSTALL_PREFIX}})
   string(REPLACE "-" "_" pkg_with_underscores ${{pkg}})
+  string(TOLOWER "${{pkg_with_underscores}}" pkg_with_underscores)
   if (COMMAND set_${{pkg_with_underscores}}_variables)
     cmake_language(CALL "set_${{pkg_with_underscores}}_variables")
   endif()
@@ -164,7 +165,8 @@ def cmake_lists(project_config, dependencies, cetmodules4):
         for d, hash, prefix in dependencies:
             if d == "cetmodules":
                 continue
-            f.write(f"\ndevelop({d})")
+            srcs_name = project_config["srcs"][d]
+            f.write(f"\ndevelop({srcs_name})")
         f.write("\n")
 
 
@@ -319,7 +321,7 @@ def ordered_roots(env, package_requirements):
     return [install_prefixes[p] for p in sorted_packages]
 
 
-def verify_no_missing_intermediate_deps(env, packages) -> None:
+def verify_no_missing_intermediate_deps(env, packages, ignored_packages) -> None:
     direct_dependents = {}
     missing_intermediate_deps = {}
 
@@ -334,6 +336,10 @@ def verify_no_missing_intermediate_deps(env, packages) -> None:
 
         # Skip the packages under development
         if n.name in packages:
+            continue
+
+        # Skip ignored packages (e.g. bundles)
+        if n.name in ignored_packages:
             continue
 
         # Package that is not under development but should be
@@ -357,11 +363,15 @@ def verify_no_missing_intermediate_deps(env, packages) -> None:
         tty.die(error_msg + "\n")
 
 
-def absent_dependencies(env, packages) -> list:
+def absent_dependencies(env, packages, ignored_packages) -> list:
     absent = []
     for n in env.all_specs():
         # Skip the packages under development
         if n.name in packages:
+            continue
+
+        # Skip ignored packages (e.g. bundles)
+        if n.name in ignored_packages:
             continue
 
         if n.install_status() == InstallStatus.absent:
@@ -606,7 +616,7 @@ def handle_installation(project_config, env, packages, yes_to_all):
     name = project_config["name"]
     local_env_dir = project_config["local"]
 
-    if absent := absent_dependencies(env, packages):
+    if absent := absent_dependencies(env, packages, project_config["ignored"]):
 
         def _parens_number(i):
             return f"({i})"
@@ -678,7 +688,7 @@ def concretize_project(project_config, yes_to_all):
         compiler_symlinks_dir,
     )
 
-    verify_no_missing_intermediate_deps(env, packages)
+    verify_no_missing_intermediate_deps(env, packages, project_config["ignored"])
 
     cmake_args = extract_cmake_args(env, packages)
 

--- a/mpd/config.py
+++ b/mpd/config.py
@@ -172,7 +172,8 @@ def spack_packages(srcs_dir):
     unknown_packages = []
     packages_to_develop = {}
     for p in srcs_repos:
-        spec = Spec(p)
+        spec_name = p.lower()
+        spec = Spec(spec_name)
         try:
             pkg_cls = PATH.get_pkg_class(spec.name)
             packages_to_develop[p] = pkg_cls(spec)
@@ -433,9 +434,9 @@ def build_all_package_requirements(
     ignored_packages = []
     languages = set()
 
-    for pkg_name, pkg in packages_to_develop.items():
+    for srcs_name, pkg in packages_to_develop.items():
         if not issubclass(type(pkg), CMakePackage):
-            ignored_packages.append(pkg_name)
+            ignored_packages.append(srcs_name)
             continue
 
         # Check languages
@@ -448,8 +449,8 @@ def build_all_package_requirements(
             if "python" in dependency:
                 languages.add("python")
 
-        packages[pkg_name] = build_package_requirements(
-            pkg_name,
+        packages[pkg.name] = build_package_requirements(
+            pkg.name,
             pkg,
             packages,
             cxxstd,
@@ -509,6 +510,17 @@ def handle_variants(project_cfg, variants, dependencies=None):
     packages_to_develop = spack_packages(project_cfg["source"])
     validate_package_variants(package_variant_map, packages_to_develop)
 
+    # Check source directory names against packages
+    pkg_to_srcs_map = {}
+    for srcs_name, pkg in packages_to_develop.items():
+        if pkg.name in pkg_to_srcs_map.keys():
+            tty.die(
+                f"Multiple source directories correspond to the same Spack package '{pkg.name}':\n"
+                f" - {pkg_to_srcs_map[pkg.name]}\n"
+                f" - {srcs_name}\n\n"
+            )
+        pkg_to_srcs_map[pkg.name] = srcs_name
+
     # Build package requirements
     packages, ignored_packages, languages = build_all_package_requirements(
         packages_to_develop, project_cfg, general_variant_map, package_variant_map
@@ -521,6 +533,7 @@ def handle_variants(project_cfg, variants, dependencies=None):
 
     # Update project configuration
     project_cfg["packages"] = packages
+    project_cfg["srcs"] = pkg_to_srcs_map
     project_cfg["ignored"] = ignored_packages
     project_cfg["dependencies"] = dependency_requirements
     project_cfg["languages"] = list(languages)


### PR DESCRIPTION
Allow for repository names that differ from Spack package names by capitalization. (This is needed for proper processing of the Mu2e Offline https://github.com/Mu2e/Offline)

If a package is in srcs, but ignored because it is not a CMakePackage, also ignore its status when checking dependencies.
Several BundlePackages are in the dependency tree of artdaq/otsdaq/Mu2e TDAQ. (i.e. artdaq-mu2e depends on otsdaq-suite). When trying to develop across bundle boundaries in MPD, we used to be able to check out the Git repository which contains an empty CMakeLists.txt to satisfy the dependency requirement. This tactic doesn't work with the dependency checking now done by Spack MPD, and it ignores the package directory in `srcs` because it is not a CMakePackage, but still considers the package while resolving dependencies.